### PR TITLE
Update scrumblr

### DIFF
--- a/check_process
+++ b/check_process
@@ -13,7 +13,7 @@
 		upgrade=1
 		#upgrade=1	from_commit=CommitHash
 		backup_restore=1
-		multi_instance=0
+		multi_instance=1
 		change_url=1
 ;;; Options
 Email=

--- a/check_process
+++ b/check_process
@@ -11,7 +11,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		#upgrade=1	from_commit=CommitHash
+		upgrade=1	from_commit=7097f3fe8fcf818f342e1971a58bc45cb8fe835c
 		backup_restore=1
 		multi_instance=1
 		change_url=1
@@ -19,7 +19,7 @@
 Email=
 Notification=none
 ;;; Upgrade options
-	; commit=CommitHash
-		name=Name and date of the commit.
+	; commit=7097f3fe8fcf818f342e1971a58bc45cb8fe835c
+		name=Merge pull request #15 
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&password=pass&port=666&
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://framagit.org/colibris/framemo/-/archive/5183db5829767363ce31acafd376a1cdfffa3eca/framemo-5183db5829767363ce31acafd376a1cdfffa3eca.tar.gz
-SOURCE_SUM=3f14e2316a5e4a8e1330c561f2506254567d7b71f0b36da9df0d9168f18e6b48
+SOURCE_URL=https://framagit.org/colibris/framemo/-/archive/d14b3167dfe413ca7db78283b70334100e82076f/framemo-d14b3167dfe413ca7db78283b70334100e82076f.tar.gz
+SOURCE_SUM=f42433ee1e513a2881d00573d0ee5d9595bcee868a8ecbaf9b219d3811aa6943
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/aliasaria/scrumblr/archive/cb1475d4f40ea422c71a9596a7ae97b0cbcbb69a.tar.gz
-SOURCE_SUM=6220540442d7327c518a948cbfb13f7f9065d24f6d4ce5c57c2b0b8e61b76714
+SOURCE_URL=https://framagit.org/colibris/framemo/-/archive/5183db5829767363ce31acafd376a1cdfffa3eca/framemo-5183db5829767363ce31acafd376a1cdfffa3eca.tar.gz
+SOURCE_SUM=3f14e2316a5e4a8e1330c561f2506254567d7b71f0b36da9df0d9168f18e6b48
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,14 +1,13 @@
-location / {
+location __PATH__/ {
+		proxy_set_header  X-Real-IP $remote_addr;
+		proxy_set_header  X-Forwarded-For $remote_addr;
+		proxy_set_header  X-Forwarded-Proto $scheme;
+		proxy_set_header  X-Forwarded-Host $http_host;
+		proxy_set_header  Host $host;
 
-  proxy_pass        http://127.0.0.1:__PORT__;
-  proxy_redirect    off;
-  proxy_set_header  Host $host;
-  proxy_set_header  X-Real-IP $remote_addr;
-  proxy_set_header  X-Forwarded-Proto $scheme;
-  proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header  X-Forwarded-Host $server_name;
-
-  # Include SSOWAT user panel.
-  include conf.d/yunohost_panel.conf.inc;
-  more_clear_input_headers 'Accept-Encoding';
+		proxy_http_version  1.1;
+		proxy_set_header    Upgrade $http_upgrade;
+		proxy_set_header    Connection $connection_upgrade;
+        
+        proxy_pass      http://localhost:__PORT____PATH__/;
 }

--- a/conf/redis.conf
+++ b/conf/redis.conf
@@ -1,0 +1,679 @@
+# Redis configuration file example.
+#
+# Note that in order to read the configuration file, Redis must be
+# started with the file path as first argument:
+#
+# ./redis-server /path/to/redis.conf
+
+# Note on units: when memory size is needed, it is possible to specify
+# it in the usual form of 1k 5GB 4M and so forth:
+#
+# 1k => 1000 bytes
+# 1kb => 1024 bytes
+# 1m => 1000000 bytes
+# 1mb => 1024*1024 bytes
+# 1g => 1000000000 bytes
+# 1gb => 1024*1024*1024 bytes
+#
+# units are case insensitive so 1GB 1Gb 1gB are all the same.
+
+
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all the network interfaces available on the server.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1 ::1
+#
+# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Redis to listen only into
+# the IPv4 loopback interface address (this means Redis will be able to
+# accept connections only from clients running into the same computer it
+# is running).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# JUST COMMENT THE FOLLOWING LINE.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bind 127.0.0.1 ::1
+
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode yes
+
+# Accept connections on the specified port, default is 6379 (IANA #815344).
+# If port 0 is specified Redis will not listen on a TCP socket.
+port __REDIS_PORT__
+
+# TCP listen() backlog.
+#
+# In high requests-per-second environments you need an high backlog in order
+# to avoid slow clients connections issues. Note that the Linux kernel
+# will silently truncate it to the value of /proc/sys/net/core/somaxconn so
+# make sure to raise both the value of somaxconn and tcp_max_syn_backlog
+# in order to get the desired effect.
+tcp-backlog 511
+
+
+# Close the connection after a client is idle for N seconds (0 to disable)
+timeout 0
+
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Take the connection alive from the point of view of network
+#    equipment in the middle.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 300 seconds, which is the new
+# Redis default starting with Redis 3.2.1.
+tcp-keepalive 300
+
+################################# GENERAL #####################################
+
+# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
+daemonize yes
+
+# If you run Redis from upstart or systemd, Redis can interact with your
+# supervision tree. Options:
+#   supervised no      - no supervision interaction
+#   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
+#   supervised auto    - detect upstart or systemd method based on
+#                        UPSTART_JOB or NOTIFY_SOCKET environment variables
+# Note: these supervision methods only signal "process is ready."
+#       They do not enable continuous liveness pings back to your supervisor.
+supervised no
+
+# If a pid file is specified, Redis writes it where specified at startup
+# and removes it at exit.
+#
+# When the server runs non daemonized, no pid file is created if none is
+# specified in the configuration. When the server is daemonized, the pid file
+# is used even if not specified, defaulting to "/var/run/redis.pid".
+#
+# Creating a pid file is best effort: if Redis is not able to create it
+# nothing bad happens, the server will start and run normally.
+pidfile /var/run/redis/redis-server__REDIS_PORT__.pid
+
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel notice
+
+# Specify the log file name. Also the empty string can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile /var/log/redis/redis-server-__REDIS_PORT__.log
+
+# Set the number of databases. The default database is DB 0, you can select
+# a different one on a per-connection basis using SELECT <dbid> where
+# dbid is a number between 0 and 'databases'-1
+databases 1
+
+
+################################ SNAPSHOTTING  ################################
+#
+# Save the DB on disk:
+#
+#   save <seconds> <changes>
+#
+#   Will save the DB if both the given number of seconds and the given
+#   number of write operations against the DB occurred.
+#
+#   In the example below the behaviour will be to save:
+#   after 900 sec (15 min) if at least 1 key changed
+#   after 300 sec (5 min) if at least 10 keys changed
+#   after 60 sec if at least 10000 keys changed
+#
+#   Note: you can disable saving completely by commenting out all "save" lines.
+#
+#   It is also possible to remove all the previously configured save
+#   points by adding a save directive with a single empty string argument
+#   like in the following example:
+#
+#   save ""
+
+save 900 1
+save 300 10
+save 60 10000
+
+# By default Redis will stop accepting writes if RDB snapshots are enabled
+# (at least one save point) and the latest background save failed.
+# This will make the user aware (in a hard way) that data is not persisting
+# on disk properly, otherwise chances are that no one will notice and some
+# disaster will happen.
+#
+# If the background saving process will start working again Redis will
+# automatically allow writes again.
+#
+# However if you have setup your proper monitoring of the Redis server
+# and persistence, you may want to disable this feature so that Redis will
+# continue to work as usual even if there are problems with disk,
+# permissions, and so forth.
+stop-writes-on-bgsave-error yes
+
+# Compress string objects using LZF when dump .rdb databases?
+# For default that's set to 'yes' as it's almost always a win.
+# If you want to save some CPU in the saving child set it to 'no' but
+# the dataset will likely be bigger if you have compressible values or keys.
+rdbcompression yes
+
+# Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
+# This makes the format more resistant to corruption but there is a performance
+# hit to pay (around 10%) when saving and loading RDB files, so you can disable it
+# for maximum performances.
+#
+# RDB files created with checksum disabled have a checksum of zero that will
+# tell the loading code to skip the check.
+rdbchecksum yes
+
+# The filename where to dump the DB
+dbfilename redis-__APP__.rdb
+
+# The working directory.
+#
+# The DB will be written inside this directory, with the filename specified
+# above using the 'dbfilename' configuration directive.
+#
+# The Append Only File will also be created inside this directory.
+#
+# Note that you must specify a directory here, not a file name.
+dir __FINAL_PATH__
+
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a replica performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transferred.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives:
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+
+############################## APPEND ONLY MODE ###############################
+
+# By default Redis asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Redis process or
+# a power outage may result into a few minutes of writes lost (depending on
+# the configured save points).
+#
+# The Append Only File is an alternative persistence mode that provides
+# much better durability. For instance using the default data fsync policy
+# (see later in the config file) Redis can lose just one second of writes in a
+# dramatic event like a server power outage, or a single write if something
+# wrong with the Redis process itself happens, but the operating system is
+# still running correctly.
+#
+# AOF and RDB persistence can be enabled at the same time without problems.
+# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# with the better durability guarantees.
+#
+# Please check http://redis.io/topics/persistence for more information.
+
+appendonly no
+
+# The name of the append only file (default: "appendonly.aof")
+
+appendfilename "appendonly.aof"
+
+# The fsync() call tells the Operating System to actually write data on disk
+# instead of waiting for more data in the output buffer. Some OS will really flush
+# data on disk, some other OS will just try to do it ASAP.
+#
+# Redis supports three different modes:
+#
+# no: don't fsync, just let the OS flush the data when it wants. Faster.
+# always: fsync after every write to the append only log. Slow, Safest.
+# everysec: fsync only one time every second. Compromise.
+#
+# The default is "everysec", as that's usually the right compromise between
+# speed and data safety. It's up to you to understand if you can relax this to
+# "no" that will let the operating system flush the output buffer when
+# it wants, for better performances (but if you can live with the idea of
+# some data loss consider the default persistence mode that's snapshotting),
+# or on the contrary, use "always" that's very slow but a bit safer than
+# everysec.
+#
+# More details please check the following article:
+# http://antirez.com/post/redis-persistence-demystified.html
+#
+# If unsure, use "everysec".
+
+# appendfsync always
+appendfsync everysec
+# appendfsync no
+
+# When the AOF fsync policy is set to always or everysec, and a background
+# saving process (a background save or AOF log background rewriting) is
+# performing a lot of I/O against the disk, in some Linux configurations
+# Redis may block too long on the fsync() call. Note that there is no fix for
+# this currently, as even performing fsync in a different thread will block
+# our synchronous write(2) call.
+#
+# In order to mitigate this problem it's possible to use the following option
+# that will prevent fsync() from being called in the main process while a
+# BGSAVE or BGREWRITEAOF is in progress.
+#
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none". In practical terms, this means that it is
+# possible to lose up to 30 seconds of log in the worst scenario (with the
+# default Linux settings).
+#
+# If you have latency problems turn this to "yes". Otherwise leave it as
+# "no" that is the safest pick from the point of view of durability.
+
+no-appendfsync-on-rewrite no
+
+# Automatic rewrite of the append only file.
+# Redis is able to automatically rewrite the log file implicitly calling
+# BGREWRITEAOF when the AOF log size grows by the specified percentage.
+#
+# This is how it works: Redis remembers the size of the AOF file after the
+# latest rewrite (if no rewrite has happened since the restart, the size of
+# the AOF at startup is used).
+#
+# This base size is compared to the current size. If the current size is
+# bigger than the specified percentage, the rewrite is triggered. Also
+# you need to specify a minimal size for the AOF file to be rewritten, this
+# is useful to avoid rewriting the AOF file even if the percentage increase
+# is reached but it is still pretty small.
+#
+# Specify a percentage of zero in order to disable the automatic AOF
+# rewrite feature.
+
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+
+# An AOF file may be found to be truncated at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running
+# crashes, especially when an ext4 filesystem is mounted without the
+# data=ordered option (however this can't happen when Redis itself
+# crashes or aborts but the operating system still works correctly).
+#
+# Redis can either exit with an error when this happens, or load as much
+# data as possible (the default now) and start if the AOF file is found
+# to be truncated at the end. The following option controls this behavior.
+#
+# If aof-load-truncated is set to yes, a truncated AOF file is loaded and
+# the Redis server starts emitting a log to inform the user of the event.
+# Otherwise if the option is set to no, the server aborts with an error
+# and refuses to start. When the option is set to no, the user requires
+# to fix the AOF file using the "redis-check-aof" utility before to restart
+# the server.
+#
+# Note that if the AOF file will be found to be corrupted in the middle
+# the server will still exit with an error. This option only applies when
+# Redis will try to read more data from the AOF file but not enough bytes
+# will be found.
+aof-load-truncated yes
+
+# When rewriting the AOF file, Redis is able to use an RDB preamble in the
+# AOF file for faster rewrites and recoveries. When this option is turned
+# on the rewritten AOF file is composed of two different stanzas:
+#
+#   [RDB file][AOF tail]
+#
+# When loading Redis recognizes that the AOF file starts with the "REDIS"
+# string and loads the prefixed RDB file, and continues loading the AOF
+# tail.
+aof-use-rdb-preamble yes
+
+################################ LUA SCRIPTING  ###############################
+
+# Max execution time of a Lua script in milliseconds.
+#
+# If the maximum execution time is reached Redis will log that a script is
+# still in execution after the maximum allowed time and will start to
+# reply to queries with an error.
+#
+# When a long running script exceeds the maximum execution time only the
+# SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
+# used to stop a script that did not yet called write commands. The second
+# is the only way to shut down the server in the case a write command was
+# already issued by the script but the user doesn't want to wait for the natural
+# termination of the script.
+#
+# Set it to 0 or a negative value for unlimited execution without warnings.
+lua-time-limit 5000
+
+################################## SLOW LOG ###################################
+
+# The Redis Slow Log is a system to log queries that exceeded a specified
+# execution time. The execution time does not include the I/O operations
+# like talking with the client, sending the reply and so forth,
+# but just the time needed to actually execute the command (this is the only
+# stage of command execution where the thread is blocked and can not serve
+# other requests in the meantime).
+#
+# You can configure the slow log with two parameters: one tells Redis
+# what is the execution time, in microseconds, to exceed in order for the
+# command to get logged, and the other parameter is the length of the
+# slow log. When a new command is logged the oldest one is removed from the
+# queue of logged commands.
+
+# The following time is expressed in microseconds, so 1000000 is equivalent
+# to one second. Note that a negative number disables the slow log, while
+# a value of zero forces the logging of every command.
+slowlog-log-slower-than 10000
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the slow log with SLOWLOG RESET.
+slowlog-max-len 128
+
+################################ LATENCY MONITOR ##############################
+
+# The Redis latency monitoring subsystem samples different operations
+# at runtime in order to collect data related to possible sources of
+# latency of a Redis instance.
+#
+# Via the LATENCY command this information is available to the user that can
+# print graphs and obtain reports.
+#
+# The system only logs operations that were performed in a time equal or
+# greater than the amount of milliseconds specified via the
+# latency-monitor-threshold configuration directive. When its value is set
+# to zero, the latency monitor is turned off.
+#
+# By default latency monitoring is disabled since it is mostly not needed
+# if you don't have latency issues, and collecting data has a performance
+# impact, that while very small, can be measured under big load. Latency
+# monitoring can easily be enabled at runtime using the command
+# "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
+latency-monitor-threshold 0
+
+############################# EVENT NOTIFICATION ##############################
+
+# Redis can notify Pub/Sub clients about events happening in the key space.
+# This feature is documented at http://redis.io/topics/notifications
+#
+# For instance if keyspace events notification is enabled, and a client
+# performs a DEL operation on key "foo" stored in the Database 0, two
+# messages will be published via Pub/Sub:
+#
+# PUBLISH __keyspace@0__:foo del
+# PUBLISH __keyevent@0__:del foo
+#
+# It is possible to select the events that Redis will notify among a set
+# of classes. Every class is identified by a single character:
+#
+#  K     Keyspace events, published with __keyspace@<db>__ prefix.
+#  E     Keyevent events, published with __keyevent@<db>__ prefix.
+#  g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
+#  $     String commands
+#  l     List commands
+#  s     Set commands
+#  h     Hash commands
+#  z     Sorted set commands
+#  x     Expired events (events generated every time a key expires)
+#  e     Evicted events (events generated when a key is evicted for maxmemory)
+#  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
+#
+#  The "notify-keyspace-events" takes as argument a string that is composed
+#  of zero or multiple characters. The empty string means that notifications
+#  are disabled.
+#
+#  Example: to enable list and generic events, from the point of view of the
+#           event name, use:
+#
+#  notify-keyspace-events Elg
+#
+#  Example 2: to get the stream of the expired keys subscribing to channel
+#             name __keyevent@0__:expired use:
+#
+#  notify-keyspace-events Ex
+#
+#  By default all notifications are disabled because most users don't need
+#  this feature and the feature has some overhead. Note that if you don't
+#  specify at least one of K or E, no events will be delivered.
+notify-keyspace-events ""
+
+############################### ADVANCED CONFIG ###############################
+
+# Hashes are encoded using a memory efficient data structure when they have a
+# small number of entries, and the biggest entry does not exceed a given
+# threshold. These thresholds can be configured using the following directives.
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+
+# Lists are also encoded in a special way to save a lot of space.
+# The number of entries allowed per internal list node can be specified
+# as a fixed maximum size or a maximum number of elements.
+# For a fixed maximum size, use -5 through -1, meaning:
+# -5: max size: 64 Kb  <-- not recommended for normal workloads
+# -4: max size: 32 Kb  <-- not recommended
+# -3: max size: 16 Kb  <-- probably not recommended
+# -2: max size: 8 Kb   <-- good
+# -1: max size: 4 Kb   <-- good
+# Positive numbers mean store up to _exactly_ that number of elements
+# per list node.
+# The highest performing option is usually -2 (8 Kb size) or -1 (4 Kb size),
+# but if your use case is unique, adjust the settings as necessary.
+list-max-ziplist-size -2
+
+# Lists may also be compressed.
+# Compress depth is the number of quicklist ziplist nodes from *each* side of
+# the list to *exclude* from compression.  The head and tail of the list
+# are always uncompressed for fast push/pop operations.  Settings are:
+# 0: disable all list compression
+# 1: depth 1 means "don't start compressing until after 1 node into the list,
+#    going from either the head or tail"
+#    So: [head]->node->node->...->node->[tail]
+#    [head], [tail] will always be uncompressed; inner nodes will compress.
+# 2: [head]->[next]->node->node->...->node->[prev]->[tail]
+#    2 here means: don't compress head or head->next or tail->prev or tail,
+#    but compress all nodes between them.
+# 3: [head]->[next]->[next]->node->node->...->node->[prev]->[prev]->[tail]
+# etc.
+list-compress-depth 0
+
+# Sets have a special encoding in just one case: when a set is composed
+# of just strings that happen to be integers in radix 10 in the range
+# of 64 bit signed integers.
+# The following configuration setting sets the limit in the size of the
+# set in order to use this special memory saving encoding.
+set-max-intset-entries 512
+
+# Similarly to hashes and lists, sorted sets are also specially encoded in
+# order to save a lot of space. This encoding is only used when the length and
+# elements of a sorted set are below the following limits:
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+
+# HyperLogLog sparse representation bytes limit. The limit includes the
+# 16 bytes header. When an HyperLogLog using the sparse representation crosses
+# this limit, it is converted into the dense representation.
+#
+# A value greater than 16000 is totally useless, since at that point the
+# dense representation is more memory efficient.
+#
+# The suggested value is ~ 3000 in order to have the benefits of
+# the space efficient encoding without slowing down too much PFADD,
+# which is O(N) with the sparse encoding. The value can be raised to
+# ~ 10000 when CPU is not a concern, but space is, and the data set is
+# composed of many HyperLogLogs with cardinality in the 0 - 15000 range.
+hll-sparse-max-bytes 3000
+
+# Streams macro node max size / items. The stream data structure is a radix
+# tree of big nodes that encode multiple items inside. Using this configuration
+# it is possible to configure how big a single node can be in bytes, and the
+# maximum number of items it may contain before switching to a new node when
+# appending new stream entries. If any of the following settings are set to
+# zero, the limit is ignored, so for instance it is possible to set just a
+# max entires limit by setting max-bytes to 0 and max-entries to the desired
+# value.
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+
+# Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
+# order to help rehashing the main Redis hash table (the one mapping top-level
+# keys to values). The hash table implementation Redis uses (see dict.c)
+# performs a lazy rehashing: the more operation you run into a hash table
+# that is rehashing, the more rehashing "steps" are performed, so if the
+# server is idle the rehashing is never complete and some more memory is used
+# by the hash table.
+#
+# The default is to use this millisecond 10 times every second in order to
+# actively rehash the main dictionaries, freeing memory when possible.
+#
+# If unsure:
+# use "activerehashing no" if you have hard latency requirements and it is
+# not a good thing in your environment that Redis can reply from time to time
+# to queries with 2 milliseconds delay.
+#
+# use "activerehashing yes" if you don't have such hard requirements but
+# want to free memory asap when possible.
+activerehashing yes
+
+# The client output buffer limits can be used to force disconnection of clients
+# that are not reading data from the server fast enough for some reason (a
+# common reason is that a Pub/Sub client can't consume messages as fast as the
+# publisher can produce them).
+#
+# The limit can be set differently for the three different classes of clients:
+#
+# normal -> normal clients including MONITOR clients
+# replica  -> replica clients
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
+#
+# The syntax of every client-output-buffer-limit directive is the following:
+#
+# client-output-buffer-limit <class> <hard limit> <soft limit> <soft seconds>
+#
+# A client is immediately disconnected once the hard limit is reached, or if
+# the soft limit is reached and remains reached for the specified number of
+# seconds (continuously).
+# So for instance if the hard limit is 32 megabytes and the soft limit is
+# 16 megabytes / 10 seconds, the client will get disconnected immediately
+# if the size of the output buffers reach 32 megabytes, but will also get
+# disconnected if the client reaches 16 megabytes and continuously overcomes
+# the limit for 10 seconds.
+#
+# By default normal clients are not limited because they don't receive data
+# without asking (in a push way), but just after a request, so only
+# asynchronous clients may create a scenario where data is requested faster
+# than it can read.
+#
+# Instead there is a default limit for pubsub and replica clients, since
+# subscribers and replicas receive data in a push fashion.
+#
+# Both the hard or the soft limit can be disabled by setting them to zero.
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+# Redis calls an internal function to perform many background tasks, like
+# closing connections of clients in timeout, purging expired keys that are
+# never requested, and so forth.
+#
+# Not all tasks are performed with the same frequency, but Redis checks for
+# tasks to perform according to the specified "hz" value.
+#
+# By default "hz" is set to 10. Raising the value will use more CPU when
+# Redis is idle, but at the same time will make Redis more responsive when
+# there are many keys expiring at the same time, and timeouts may be
+# handled with more precision.
+#
+# The range is between 1 and 500, however a value over 100 is usually not
+# a good idea. Most users should use the default of 10 and raise this up to
+# 100 only in environments where very low latency is required.
+hz 10
+
+# Normally it is useful to have an HZ value which is proportional to the
+# number of clients connected. This is useful in order, for instance, to
+# avoid too many clients are processed for each background task invocation
+# in order to avoid latency spikes.
+#
+# Since the default HZ value by default is conservatively set to 10, Redis
+# offers, and enables by default, the ability to use an adaptive HZ value
+# which will temporary raise when there are many connected clients.
+#
+# When dynamic HZ is enabled, the actual configured HZ will be used as
+# as a baseline, but multiples of the configured HZ value will be actually
+# used as needed once more clients are connected. In this way an idle
+# instance will use very little CPU time while a busy instance will be
+# more responsive.
+dynamic-hz yes
+
+# When a child rewrites the AOF file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+aof-rewrite-incremental-fsync yes
+
+# When redis saves RDB file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+rdb-save-incremental-fsync yes

--- a/conf/redis.conf
+++ b/conf/redis.conf
@@ -100,7 +100,7 @@ tcp-keepalive 300
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-daemonize yes
+daemonize no
 
 # If you run Redis from upstart or systemd, Redis can interact with your
 # supervision tree. Options:
@@ -122,7 +122,7 @@ supervised no
 #
 # Creating a pid file is best effort: if Redis is not able to create it
 # nothing bad happens, the server will start and run normally.
-pidfile /var/run/redis/redis-server__REDIS_PORT__.pid
+pidfile __FINAL_PATH__/redis-server-__REDIS_PORT__.pid
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -135,7 +135,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile /var/log/redis/redis-server-__REDIS_PORT__.log
+logfile /var/log/__APP__/redis-__REDIS_PORT__.log
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where

--- a/conf/scrumblr_redis.service
+++ b/conf/scrumblr_redis.service
@@ -7,41 +7,32 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/
-ExecStart=redis-server redis.conf 
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=redis-__APP__
+ExecStart=/usr/bin/redis-server __FINALPATH__/redis.conf 
+ExecStop=/bin/kill -s TERM $MAINPID
+PIDFile=__FINALPATH__/redis-server-__PORT__.pid
+TimeoutStopSec=0
 Restart=always
 
-# Sandboxing options to harden security
-# Depending on specificities of your service/app, you may need to tweak these 
-# .. but this should be a good baseline
-# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
-NoNewPrivileges=yes
+UMask=007
 PrivateTmp=yes
+LimitNOFILE=65535
 PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-RestrictNamespaces=yes
-RestrictRealtime=yes
-DevicePolicy=closed
-ProtectSystem=full
-ProtectControlGroups=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-LockPersonality=yes
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+ProtectHome=yes
+#ReadOnlyDirectories=/
+ReadWriteDirectories=-/var/lib/__APP__
+ReadWriteDirectories=-/var/log/__APP__
+ReadWriteDirectories=-__FINALPATH__
 
-# Denying access to capabilities that should not be relevant for webapps
-# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
-CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
-CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
-CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
-CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
-CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
-CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
-CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
-CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
-CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG 
+NoNewPrivileges=true
+CapabilityBoundingSet=CAP_SETGID CAP_SETUID CAP_SYS_RESOURCE
+MemoryDenyWriteExecute=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictNamespaces=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+
 
 [Install]
 WantedBy=multi-user.target

--- a/conf/scrumblr_redis.service
+++ b/conf/scrumblr_redis.service
@@ -1,15 +1,16 @@
 [Unit]
-Description=Scrumblr: software to take note.
+Description=Redis service for scrumblr app.
 After=network.target
 
 [Service]
 Type=simple
 User=__APP__
 Group=__APP__
-WorkingDirectory=__FINALPATH__
-Environment="PATH=_PATH__"
-Environment="NODE_ENV=production"
-ExecStart=__YNH_NODE__ server.js --port=__PORT__ --baseurl=__PATH__ --redis localhot:__REDIS_PORT__
+WorkingDirectory=__FINALPATH__/
+ExecStart=redis-server redis.conf 
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=redis-__APP__
 Restart=always
 
 # Sandboxing options to harden security
@@ -44,4 +45,3 @@ CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
 
 [Install]
 WantedBy=multi-user.target
-

--- a/conf/scrumblr_redis.service
+++ b/conf/scrumblr_redis.service
@@ -9,7 +9,7 @@ Group=__APP__
 WorkingDirectory=__FINALPATH__/
 ExecStart=/usr/bin/redis-server __FINALPATH__/redis.conf 
 ExecStop=/bin/kill -s TERM $MAINPID
-PIDFile=__FINALPATH__/redis-server-__PORT__.pid
+PIDFile=__FINALPATH__/redis-server-__REDIS_PORT__.pid
 TimeoutStopSec=0
 Restart=always
 

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,10 +7,41 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__
-Environment="PATH=__ENV_PATH__"
+Environment="PATH=_PATH__"
 Environment="NODE_ENV=production"
-ExecStart=__YNH_NPM__ start --server:port=__PORT__
+ExecStart=__YNH_NODE__ server.js --port=__PORT__ --baseurl=__PATH__
 Restart=always
+
+# Sandboxing options to harden security
+# Depending on specificities of your service/app, you may need to tweak these 
+# .. but this should be a good baseline
+# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+DevicePolicy=closed
+ProtectSystem=full
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+LockPersonality=yes
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+
+# Denying access to capabilities that should not be relevant for webapps
+# Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
+CapabilityBoundingSet=~CAP_RAWIO CAP_MKNOD
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_SYS_BOOT CAP_SYS_TIME CAP_SYS_MODULE CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG 
 
 [Install]
 WantedBy=multi-user.target
+

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Scrumblr: software to take note.
-After=network.target
+Requires=redis-__APP__.service
 
 [Service]
 Type=simple
@@ -9,7 +9,7 @@ Group=__APP__
 WorkingDirectory=__FINALPATH__
 Environment="PATH=_PATH__"
 Environment="NODE_ENV=production"
-ExecStart=__YNH_NODE__ server.js --port=__PORT__ --baseurl=__PATH__ --redis localhot:__REDIS_PORT__
+ExecStart=__YNH_NODE__ server.js --port=__PORT__ --baseurl=__PATH__ --redis localhost:__REDIS_PORT__
 Restart=always
 
 # Sandboxing options to harden security

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,12 @@
                 "type": "domain"
             },
             {
+                "name": "path",
+                "type": "path",
+                "example": "/scrumblr",
+                "default": "/scrumblr"
+            },
+            {
                 "name": "is_public",
                 "type": "boolean",
                 "help": {

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
         "license": "AGPL-3.0-only",
         "website": "http://www.scrumblr.ca/",
         "demo": "http://scrumblr.ca/",
-        "code": "https://github.com/aliasaria/scrumblr"
+        "code": "https://framagit.org/colibris/framemo"
     },
     "license": "AGPL-3.0-only",
     "maintainer": [{

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
     "requirements": {
         "yunohost": ">> 4.3.0"
     },
-    "multi_instance": false,
+    "multi_instance": true,
     "services": [
         "nginx"
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Software for post-it notes",
 	   "fr": "Application pour créer des post-it"
     },
-    "version": "0.2.0~ynh1",
+    "version": "0.2.1~ynh1",
     "url": "http://www.scrumblr.ca/",
     "upstream": {
         "license": "AGPL-3.0-only",
@@ -15,10 +15,13 @@
         "code": "https://github.com/aliasaria/scrumblr"
     },
     "license": "AGPL-3.0-only",
-    "maintainer": {
+    "maintainer": [{
         "name": "frju365",
         "email": "win10@tutanota.com"
     },
+    {   "name": "oiseauroch",
+        "email": "tobias.ollive@oiseauroch.fr"
+    }],
     "requirements": {
         "yunohost": ">> 4.3.0"
     },

--- a/scripts/backup
+++ b/scripts/backup
@@ -30,13 +30,20 @@ app=$YNH_APP_INSTANCE_NAME
 
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+redis_port=$(ynh_app_setting_get --app=$app --key=redis_port)
 codename=$(ynh_app_setting_get $app codename)
 
 #=================================================
 # DECLARE DATA AND CONF FILES TO BACKUP
 #=================================================
 ynh_print_info --message="Declaring files to be backed up..."
+
+
+#=================================================
+# EXPORT DATABASE
+#=================================================
+
+redis-cli --rdb "$final_path/redis-$app.rdb" -p $redis_port
 
 #=================================================
 # BACKUP THE APP MAIN DIR
@@ -63,6 +70,7 @@ ynh_backup --src_path="/etc/logrotate.d/$app"
 #=================================================
 
 ynh_backup --src_path="/etc/systemd/system/$app.service"
+ynh_backup --src_path="/etc/systemd/system/redis-$app.service"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -17,7 +17,7 @@ old_domain=$YNH_APP_OLD_DOMAIN
 old_path=$YNH_APP_OLD_PATH
 
 new_domain=$YNH_APP_NEW_DOMAIN
-new_path="/"
+new_path=$YNH_APP_NEW_PATH
 
 app=$YNH_APP_INSTANCE_NAME
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -108,7 +108,7 @@ fi
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=5
 
-ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at port"
+ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -101,6 +101,15 @@ then
 	ynh_store_file_checksum --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
 fi
 
+
+#=================================================
+# CHANGE SYSTEMD SERVICE
+#=================================================
+if [ $change_path -eq 1 ]
+then
+    ynh_replace_string --match-string=$old_path --replace-string=$new_path --target-file="/etc/systemd/system/$app.service"
+fi
+
 #=================================================
 # GENERIC FINALISATION
 #=================================================

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -110,7 +110,7 @@ ynh_script_progression --message="Updating systemd configuration..." --weight=1
 if [ $change_path -eq 1 ]
 then
     ynh_replace_string --match_string=$old_path --replace_string=$new_path --target_file="/etc/systemd/system/$app.service"
-    systemctl deamon-reload
+    systemctl daemon-reload
 fi
 
 #=================================================

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -109,7 +109,7 @@ ynh_script_progression --message="Updating systemd configuration..." --weight=1
 
 if [ $change_path -eq 1 ]
 then
-    ynh_replace_string --match_string=$old_path --replace_string=$new_path --target_file="/etc/systemd/system/$app.service"
+    ynh_replace_string --match_string="--baseurl=$old_path" --replace_string="--baseurl=$new_path" --target_file="/etc/systemd/system/$app.service"
     systemctl daemon-reload
 fi
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -105,9 +105,11 @@ fi
 #=================================================
 # CHANGE SYSTEMD SERVICE
 #=================================================
+ynh_script_progression --message="Updating systemd configuration..." --weight=1
+
 if [ $change_path -eq 1 ]
 then
-    ynh_replace_string --match-string=$old_path --replace-string=$new_path --target-file="/etc/systemd/system/$app.service"
+    ynh_replace_string --match_string=$old_path --replace_string=$new_path --target_file="/etc/systemd/system/$app.service"
 fi
 
 #=================================================

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -110,6 +110,7 @@ ynh_script_progression --message="Updating systemd configuration..." --weight=1
 if [ $change_path -eq 1 ]
 then
     ynh_replace_string --match_string=$old_path --replace_string=$new_path --target_file="/etc/systemd/system/$app.service"
+    systemctl deamon-reload
 fi
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -24,7 +24,7 @@ ynh_abort_if_errors
 #=================================================
 
 domain=$YNH_APP_ARG_DOMAIN
-path_url="/"
+path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
 
 app=$YNH_APP_INSTANCE_NAME
@@ -110,7 +110,6 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Configuring a systemd service..." --weight=1
 
-ynh_replace_string --match_string="__ENV_PATH__" --replace_string="$PATH" --target_file="../conf/systemd.service"
 ynh_add_systemd_config
 
 #=================================================
@@ -135,7 +134,7 @@ yunohost service add $app --description="Software for notes" --log="/var/log/$ap
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at port"
+ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at "
 
 #=================================================
 # Set Public or private

--- a/scripts/install
+++ b/scripts/install
@@ -59,12 +59,29 @@ ynh_script_progression --message="Finding an available port..." --weight=1
 port=$(ynh_find_port --port=8080)
 ynh_app_setting_set --app=$app --key=port --value=$port
 
+#==================================================
+# CONFIGURE REDIS SERVICE
+#==================================================
+
+ynh_install_app_dependencies redis-server redis-tools
+
+# Find an available port for redis
+redis_port=$(ynh_find_port --port=8081)
+ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
+
+ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
+
+redis_service="redis-$app$"
+ynh_add_systemd_config --service $redis_service --template scrumblr_redis
+
 #=================================================
 # INSTALL NODEJS
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --weight=5
 
 ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
+
+
 
 #=================================================
 # CREATE DEDICATED USER

--- a/scripts/install
+++ b/scripts/install
@@ -59,21 +59,6 @@ ynh_script_progression --message="Finding an available port..." --weight=1
 port=$(ynh_find_port --port=8080)
 ynh_app_setting_set --app=$app --key=port --value=$port
 
-#==================================================
-# CONFIGURE REDIS SERVICE
-#==================================================
-
-ynh_install_app_dependencies redis-server redis-tools
-
-# Find an available port for redis
-redis_port=$(ynh_find_port --port=8081)
-ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
-
-ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
-
-redis_service="redis-$app$"
-ynh_add_systemd_config --service $redis_service --template scrumblr_redis
-
 #=================================================
 # INSTALL NODEJS
 #=================================================
@@ -100,10 +85,25 @@ ynh_app_setting_set --app=$app --key=final_path --value=$final_path
 # Download, check integrity, uncompress and patch the source from app.src
 ynh_setup_source --dest_dir="$final_path"
 
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
+#==================================================
+# CONFIGURE REDIS SERVICE
+#==================================================
 
+ynh_install_app_dependencies redis-server redis-tools
+
+# Find an available port for redis
+redis_port=$(ynh_find_port --port=8081)
+ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
+
+ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
+
+redis_service="redis-$app"
+ynh_add_systemd_config --service $redis_service --template scrumblr_redis.service
+
+
+chmod 770 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:$app "$final_path"
 #=================================================
 # NGINX CONFIGURATION
 #=================================================
@@ -121,6 +121,8 @@ ynh_script_progression --message="Configuring log rotation..." --weight=1
 
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate
+
+chown -R $app:$app "/var/log/$app/"
 
 #=================================================
 # SETUP SYSTEMD

--- a/scripts/remove
+++ b/scripts/remove
@@ -54,6 +54,13 @@ ynh_script_progression --message="Removing logrotate configuration..." --weight=
 ynh_remove_logrotate
 
 #=================================================
+# REMOVE LOG DIR
+#=================================================
+ynh_script_progression --message="Removing log dir..." --weight=1
+
+ynh_secure_remove --file="/var/log/$app"
+
+#=================================================
 # REMOVE DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Removing dependencies..." --weight=2

--- a/scripts/remove
+++ b/scripts/remove
@@ -57,6 +57,10 @@ ynh_script_progression --message="Removing dependencies..." --weight=2
 # Remove metapackage and its dependencies
 ynh_remove_nodejs
 
+ynh_script_progression --message="Removing redis service" --weight=2
+
+ynh_remove_systemd_config --service="redis-$app"
+
 #=================================================
 # REMOVE APP MAIN DIR
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -41,6 +41,10 @@ ynh_script_progression --message="Stopping and removing the systemd service..." 
 # Remove the dedicated systemd config
 ynh_remove_systemd_config
 
+ynh_remove_systemd_config --service="redis-$app"
+
+
+
 #=================================================
 # REMOVE LOGROTATE CONFIGURATION
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -63,10 +63,6 @@ ynh_script_progression --message="Restoring the app main directory..." --weight=
 
 ynh_restore_file --origin_path="$final_path"
 
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
-
 #=================================================
 # SPECIFIC RESTORATION
 #=================================================
@@ -91,6 +87,10 @@ ynh_script_progression --message="Restoring the redis configuration..." --weight
 
 ynh_restore_file --origin_path="/etc/systemd/system/redis-$app.service"
 systemctl enable "redis-$app.service" --quiet
+
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:redis "$final_path"
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,6 +85,8 @@ systemctl enable $app.service --quiet
 #=================================================
 ynh_script_progression --message="Restoring the redis configuration..." --weight=1
 
+ynh_install_app_dependencies redis-server redis-tools
+
 ynh_restore_file --origin_path="/etc/systemd/system/redis-$app.service"
 systemctl enable "redis-$app.service" --quiet
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -90,15 +90,19 @@ systemctl enable "redis-$app.service" --quiet
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R $app:redis "$final_path"
+chown -R $app:$app "$final_path"
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION
 #=================================================
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
 
-ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 
+# recreate log directory in case of restoring backup in a new installation
+mkdir --parents /var/log/$app
+chown -R $app:$app "/var/log/$app/"
+
+ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -85,6 +85,14 @@ ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
 systemctl enable $app.service --quiet
 
 #=================================================
+# RESTORE redis service
+#=================================================
+ynh_script_progression --message="Restoring the redis configuration..." --weight=1
+
+ynh_restore_file --origin_path="/etc/systemd/system/redis-$app.service"
+systemctl enable "redis-$app.service" --quiet
+
+#=================================================
 # RESTORE THE LOGROTATE CONFIGURATION
 #=================================================
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
@@ -103,7 +111,7 @@ yunohost service add $app --description="Software for notes" --log="/var/log/$ap
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at port"
+ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -185,6 +185,9 @@ ynh_script_progression --message="Upgrading logrotate configuration..." --weight
 # Use logrotate to manage app-specific logfile(s)
 ynh_use_logrotate --non-append
 
+#fix log directory owner
+chown -R $app:$app /var/log/$app
+
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,10 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 port=$(ynh_app_setting_get --app=$app --key=port)
+if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1" ] 
+then
+    redis_port=$(ynh_app_setting_get --app=$app --key=redis_port)
+fi
 
 #=================================================
 # CHECK VERSION
@@ -50,6 +54,10 @@ ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
 
+if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2" ] 
+then
+    ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"ls
+fi
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
@@ -100,6 +108,35 @@ then
 		ynh_exec_warn_less $ynh_npm install
 	popd
 fi
+
+#=================================================
+# MIGRATE DATABASE
+#=================================================
+ynh_script_progression --message="migrating database..." --weight=1
+
+if [ $(ynh_compare_current_package_version "0.2.0~ynh1" ] 
+then
+    pushd $final_path
+        redis-cli --rdb "redis-$app.rdb"
+    popd
+fi
+
+#=================================================
+# REDIS CONFIGURATION
+#=================================================
+
+if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2" ] 
+then
+# Find an available port for redis
+    redis_port=$(ynh_find_port --port=8081)
+    ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
+fi
+
+ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
+
+redis_service="redis-$app$"
+ynh_add_systemd_config --service $redis_service --template scrumblr_redis
+
 #=================================================
 # NGINX CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,7 +20,7 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 port=$(ynh_app_setting_get --app=$app --key=port)
-if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1" ] 
+if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") ] 
 then
     redis_port=$(ynh_app_setting_get --app=$app --key=redis_port)
 fi
@@ -54,7 +54,7 @@ ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
 
-if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2" ] 
+if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2") ] 
 then
     ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"ls
 fi
@@ -112,9 +112,11 @@ fi
 #=================================================
 # MIGRATE DATABASE
 #=================================================
-ynh_script_progression --message="migrating database..." --weight=1
+ynh_script_progression --message="migrating database... $(ynh_package_version --package=scrumblr)" --weight=1
 
-if [ $(ynh_compare_current_package_version "0.2.0~ynh1" ] 
+
+
+if [  $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2")  ] 
 then
     pushd $final_path
         redis-cli --rdb "redis-$app.rdb"
@@ -125,7 +127,7 @@ fi
 # REDIS CONFIGURATION
 #=================================================
 
-if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2" ] 
+if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2") ] 
 then
 # Find an available port for redis
     redis_port=$(ynh_find_port --port=8081)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,7 +20,8 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 port=$(ynh_app_setting_get --app=$app --key=port)
-if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") ] 
+
+if ynh_compare_current_package_version --comparison gt --version 0.2.0~ynh1
 then
     redis_port=$(ynh_app_setting_get --app=$app --key=redis_port)
 else
@@ -57,7 +58,7 @@ ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
 
-if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") ] 
+if $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1")
 then
     ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"
 fi
@@ -117,7 +118,7 @@ echo "$(ynh_package_version --package=srumblr)"
 
 
 
-if [  $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2")  ] 
+if $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2") 
 then
     pushd $final_path
         redis-cli --rdb "redis-$app.rdb"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -62,6 +62,11 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app
 
 if $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1")
 then
+    # save redis db
+    pushd $final_path
+        redis-cli --rdb "/tmp/redis-$app.rdb" -p $redis_port
+    popd
+    
     ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"
 fi
 #=================================================
@@ -97,10 +102,16 @@ ynh_system_user_create --username=$app --home_dir="$final_path"
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
-
+    
 	ynh_secure_remove --file="$final_path"
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir="$final_path"
+	
+	# restore db backup
+	if $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") 
+    then
+        mv /tmp/redis-$app.rdb $final_path/redis-$app.rdb
+    fi
 fi
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
@@ -139,7 +150,7 @@ ynh_add_systemd_config --service $redis_service --template "scrumblr_redis.servi
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R $app:redis "$final_path"
+chown -R $app:$app "$final_path"
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -120,7 +120,6 @@ ynh_exec_warn_less ynh_install_nodejs --nodejs_version=$nodejs_version
 #=================================================
 ynh_script_progression --message="Upgrading systemd configuration..." --weight=1
 
-ynh_replace_string --match_string="__ENV_PATH__" --replace_string="$PATH" --target_file="../conf/systemd.service"
 ynh_add_systemd_config
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -35,6 +35,8 @@ fi
 
 upgrade_type=$(ynh_check_app_version_changed)
 
+ynh_install_app_dependencies redis-server redis-tools
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,6 +23,9 @@ port=$(ynh_app_setting_get --app=$app --key=port)
 if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") ] 
 then
     redis_port=$(ynh_app_setting_get --app=$app --key=redis_port)
+else
+    redis_port=$(ynh_find_port --port=8081)
+    ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
 fi
 
 #=================================================
@@ -125,17 +128,11 @@ fi
 # REDIS CONFIGURATION
 #=================================================
 
-if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2") ] 
-then
-# Find an available port for redis
-    redis_port=$(ynh_find_port --port=8081)
-    ynh_app_setting_set --app=$app --key=redis_port --value=$redis_port
-fi
 
 ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
 
-redis_service="redis-$app$"
-ynh_add_systemd_config --service $redis_service --template scrumblr_redis
+redis_service="redis-$app"
+ynh_add_systemd_config --service $redis_service --template "scrumblr_redis.service"
 
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
@@ -186,7 +183,7 @@ yunohost service add $app --description="Software for notes" --log="/var/log/$ap
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at port"
+ynh_systemd_action --service_name=$app --action="start" --log_path=systemd --line_match="Server running at"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,9 +54,9 @@ ynh_script_progression --message="Stopping a systemd service..." --weight=1
 
 ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
 
-if [ $(ynh_compare_current_package_version --comparison lt --version "0.2.0~ynh2") ] 
+if [ $(ynh_compare_current_package_version --comparison gt --version "0.2.0~ynh1") ] 
 then
-    ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"ls
+    ynh_systemd_action --service_name=redis-$app --action="stop" --log_path="/var/log/$app/redis-$app.log"
 fi
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -97,10 +97,6 @@ then
 	ynh_setup_source --dest_dir="$final_path"
 fi
 
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
-
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	pushd $final_path
@@ -113,6 +109,8 @@ fi
 # MIGRATE DATABASE
 #=================================================
 ynh_script_progression --message="migrating database... $(ynh_package_version --package=scrumblr)" --weight=1
+
+echo "$(ynh_package_version --package=srumblr)"
 
 
 
@@ -138,6 +136,11 @@ ynh_add_config --template="redis.conf" --destination="$final_path/redis.conf"
 
 redis_service="redis-$app$"
 ynh_add_systemd_config --service $redis_service --template scrumblr_redis
+
+chmod 750 "$final_path"
+chmod -R o-rwx "$final_path"
+chown -R $app:redis "$final_path"
+
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
Hello, scrumblr is no more actively maintained. I discussed with colibri team to use their own repository with app debranded.

This version should allow to install scrumblr in a subpath. 
Moreover, scrumblr uses a redis database to store data. Currently, the database is not saved and redis doesn't really allow to save a unique database. This new version spawn a specific redis process for scrumblr so that it can be backup and restored.